### PR TITLE
OwnableValidator with better API and without the linked list

### DIFF
--- a/src/ContangoOwnableValidator/ContangoOwnableValidator.sol
+++ b/src/ContangoOwnableValidator/ContangoOwnableValidator.sol
@@ -11,7 +11,6 @@ import { MODULE_TYPE_STATELESS_VALIDATOR as TYPE_STATELESS_VALIDATOR } from
     "modulekit/module-bases/utils/ERC7579Constants.sol";
 
 contract ContangoOwnableValidator is ERC7579ValidatorBase {
-
     using LibSort for *;
     using EnumerableSet for EnumerableSet.AddressSet;
 
@@ -27,8 +26,6 @@ contract ContangoOwnableValidator is ERC7579ValidatorBase {
 
     error InvalidThreshold(uint256 threshold, uint256 minThreshold, uint256 maxThreshold);
     error InvalidOwnersCount(uint256 ownersCount, uint256 minOwnersCount, uint256 maxOwnersCount);
-    error OwnerAlreadyExists(address owner);
-    error OwnerDoesNotExist(address owner);
 
     EnumerableSet.AddressSet owners;
     mapping(address account => uint256) public thresholds;
@@ -43,40 +40,24 @@ contract ContangoOwnableValidator is ERC7579ValidatorBase {
         _;
     }
 
+    // Default to the min and max value constants for the invariants
+    modifier checkInvariants() {
+        _;
+        _checkInvariants(msg.sender, MIN_OWNERS, MAX_OWNERS);
+    }
+
     /*//////////////////////////////////////////////////////////////////////////
                                      INTERNAL
     //////////////////////////////////////////////////////////////////////////*/
 
-    function _setThreshold(address account, uint256 _threshold) internal {
-        thresholds[account] = _threshold;
-        emit ThresholdSet(account, _threshold);
-    }
-
-    /**
-     * @dev EnumerableSet.add returns false if the item already exists
-     */
-    function _addOwner(address account, address owner) internal {
-        if (!owners.add(account, owner)) revert OwnerAlreadyExists(owner);
-        emit OwnerAdded(account, owner);
-    }
-
-    /**
-     * @dev EnumerableSet.remove returns false if the item does not exist
-     */
-    function _removeOwner(address account, address owner) internal {
-        if (!owners.remove(account, owner)) revert OwnerDoesNotExist(owner);
-        emit OwnerRemoved(account, owner);
-    }
-
-    function _addOwners(address account, address[] memory newOwners) internal {
-        for (uint256 i = 0; i < newOwners.length; i++) _addOwner(account, newOwners[i]);
-    }
-
-    function _removeOwners(address account, address[] memory ownersToRemove) internal {
-        for (uint256 i = 0; i < ownersToRemove.length; i++) _removeOwner(account, ownersToRemove[i]);
-    }
-
-    function _checkInvariants(address account, uint256 minOwnersCount, uint256 maxOwnersCount) internal view {
+    function _checkInvariants(
+        address account,
+        uint256 minOwnersCount,
+        uint256 maxOwnersCount
+    )
+        internal
+        view
+    {
         uint256 ownersCount = owners.length(account);
         uint256 threshold = thresholds[account];
         require(
@@ -89,9 +70,40 @@ contract ContangoOwnableValidator is ERC7579ValidatorBase {
         );
     }
 
-    // Default to the min and max value constants for the invariants
-    function _checkInvariants(address account) internal view {
-        _checkInvariants(account, MIN_OWNERS, MAX_OWNERS);
+    function _setThreshold(address account, uint256 _threshold) internal {
+        thresholds[account] = _threshold;
+        emit ThresholdSet(account, _threshold);
+    }
+
+    function _addOwners(address account, address[] memory newOwners) internal {
+        for (uint256 i = 0; i < newOwners.length; i++) {
+            // EnumerableSet.add returns false if the item already exists
+            if (owners.add(account, newOwners[i])) emit OwnerAdded(account, newOwners[i]);
+        }
+    }
+
+    function _removeOwners(address account, address[] memory ownersToRemove) internal {
+        for (uint256 i = 0; i < ownersToRemove.length; i++) {
+            // EnumerableSet.remove returns false if the item does not exist
+            if (owners.remove(account, ownersToRemove[i])) {
+                emit OwnerRemoved(account, ownersToRemove[i]);
+            }
+        }
+    }
+
+    function _updateConfig(
+        uint256 newThreshold,
+        address[] memory ownersToAdd,
+        address[] memory ownersToRemove
+    )
+        internal
+        checkInvariants
+        moduleIsInitialized
+    {
+        address account = msg.sender;
+        _removeOwners(account, ownersToRemove);
+        _addOwners(account, ownersToAdd);
+        _setThreshold(account, newThreshold);
     }
 
     /*//////////////////////////////////////////////////////////////////////////
@@ -105,52 +117,27 @@ contract ContangoOwnableValidator is ERC7579ValidatorBase {
      * @param ownersToAdd address[] array of owners to add.
      * @param ownersToRemove address[] array of owners to remove.
      */
-    function updateConfig(uint256 newThreshold, address[] calldata ownersToAdd, address[] calldata ownersToRemove) public moduleIsInitialized {
-        address account = msg.sender;
-        _removeOwners(account, ownersToRemove);
-        _addOwners(account, ownersToAdd);
-        _setThreshold(account, newThreshold);
-        _checkInvariants(account);
+    function updateConfig(
+        uint256 newThreshold,
+        address[] calldata ownersToAdd,
+        address[] calldata ownersToRemove
+    )
+        public
+    {
+        _updateConfig(newThreshold, ownersToAdd, ownersToRemove);
     }
-
-    function addOwner(address owner) external moduleIsInitialized {
-        address account = msg.sender;
-        _addOwner(account, owner);
-        _checkInvariants(account);
-    }
-    
-    function removeOwner(address owner) external moduleIsInitialized {
-        address account = msg.sender;
-        _removeOwner(account, owner);
-        _checkInvariants(account);
-    }
-
-    function setThreshold(uint256 threshold) external moduleIsInitialized {
-        address account = msg.sender;
-        _setThreshold(account, threshold);
-        _checkInvariants(account);
-    }
-
-    function replaceOwner(address prevOwner, address newOwner) external moduleIsInitialized {
-        address account = msg.sender;
-        _removeOwner(account, prevOwner);
-        _addOwner(account, newOwner);
-        _checkInvariants(account);
-    }
-
-    // ** CONFIG ** //
 
     function onInstall(bytes calldata data)
         external
         override
         moduleIsNotInitialized
+        checkInvariants
     {
         address account = msg.sender;
         (uint256 threshold, address[] memory newOwners) = abi.decode(data, (uint256, address[]));
 
         _addOwners(account, newOwners);
         _setThreshold(account, threshold);
-        _checkInvariants(account);
 
         emit ModuleInitialized(account);
     }
@@ -356,4 +343,3 @@ contract ContangoOwnableValidator is ERC7579ValidatorBase {
         return "1.0.0";
     }
 }
-

--- a/test/ContangoOwnableValidator/ContangoOwnableValidatorTest.sol
+++ b/test/ContangoOwnableValidator/ContangoOwnableValidatorTest.sol
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.23;
+
+import { BaseTest } from "test/Base.t.sol";
+import { ContangoOwnableValidator } from "src/ContangoOwnableValidator/ContangoOwnableValidator.sol";
+
+// utility contract to test the ContangoOwnableValidator
+// exposes helper methods to do one operation at a time, yet always going through
+// the updateConfig function to mimic how it would be used in a real life scenario
+contract ContangoOwnableTestValidator is ContangoOwnableValidator {
+    function addOwner(address newOwner) external {
+        address[] memory ownersToAdd = new address[](1);
+        ownersToAdd[0] = newOwner;
+        super._updateConfig(this.thresholds(msg.sender), ownersToAdd, new address[](0));
+    }
+
+    function setThreshold(uint256 newThreshold) external {
+        super._updateConfig(newThreshold, new address[](0), new address[](0));
+    }
+
+    function removeOwner(address owner) external {
+        address[] memory ownersToRemove = new address[](1);
+        address[] memory ownersToAdd = new address[](0);
+        ownersToRemove[0] = owner;
+        super._updateConfig(this.thresholds(msg.sender), ownersToAdd, ownersToRemove);
+    }
+}

--- a/test/ContangoOwnableValidator/integration/concrete/ContangoOwnableValidator.t.sol
+++ b/test/ContangoOwnableValidator/integration/concrete/ContangoOwnableValidator.t.sol
@@ -2,10 +2,11 @@
 pragma solidity ^0.8.23;
 
 import { BaseIntegrationTest, ModuleKitHelpers } from "test/BaseIntegration.t.sol";
-import { ContangoOwnableValidator } from "src/ContangoOwnableValidator/ContangoOwnableValidator.sol";
 import { signHash, signUserOpHash } from "test/utils/Signature.sol";
 import { MODULE_TYPE_VALIDATOR } from "modulekit/accounts/common/interfaces/IERC7579Module.sol";
 import { UserOpData } from "modulekit/ModuleKit.sol";
+import { ContangoOwnableTestValidator as ContangoOwnableValidator } from
+    "test/ContangoOwnableValidator/ContangoOwnableValidatorTest.sol";
 
 contract ContangoOwnableValidatorIntegrationTest is BaseIntegrationTest {
     using ModuleKitHelpers for *;
@@ -97,7 +98,9 @@ contract ContangoOwnableValidatorIntegrationTest is BaseIntegrationTest {
         instance.getExecOps({
             target: address(validator),
             value: 0,
-            callData: abi.encodeWithSelector(ContangoOwnableValidator.setThreshold.selector, newThreshold),
+            callData: abi.encodeWithSelector(
+                ContangoOwnableValidator.setThreshold.selector, newThreshold
+            ),
             txValidator: address(instance.defaultValidator)
         }).execUserOps();
 
@@ -113,7 +116,9 @@ contract ContangoOwnableValidatorIntegrationTest is BaseIntegrationTest {
         instance.getExecOps({
             target: address(validator),
             value: 0,
-            callData: abi.encodeWithSelector(ContangoOwnableValidator.setThreshold.selector, newThreshold),
+            callData: abi.encodeWithSelector(
+                ContangoOwnableValidator.setThreshold.selector, newThreshold
+            ),
             txValidator: address(instance.defaultValidator)
         }).execUserOps();
     }
@@ -146,9 +151,7 @@ contract ContangoOwnableValidatorIntegrationTest is BaseIntegrationTest {
         instance.getExecOps({
             target: address(validator),
             value: 0,
-            callData: abi.encodeWithSelector(
-                ContangoOwnableValidator.removeOwner.selector, _owners[1]
-            ),
+            callData: abi.encodeWithSelector(ContangoOwnableValidator.removeOwner.selector, _owners[1]),
             txValidator: address(instance.defaultValidator)
         }).execUserOps();
 


### PR DESCRIPTION
In this version I've added a `updateConfig` method that looks like this:

`function updateConfig(uint256 newThreshold, address[] calldata ownersToAdd, address[] calldata ownersToRemove)`

A UI that has a section to manage your signers is likely to have some component where users can do the following operations:

1. Add a new key
2. Remove an existing key
3. Change the threshold

It makes sense to just provide the UI dev with an API that can take all of these things in one go, and not have to worry about mid-batch reverts due to ordering of operations as you do with the batched transaction of the more primitive methods (addOwner, removeOwner, setThreshold). That said, this contract still has those methods too, if we ever want to use them. 

** Technical stuff ** 

- This version uses the `EnumerableSet4337` instead of `SentinelList4337`.
- The enumerable set is a better fit for what this contract needs which is just (unordered) insertions, deletions, and lookups.
- Deletions are more painful in the SentinelList compared to the set (having to pass a reference to `prev` to delete an entry)
- All the signing methods remain **exactly** the same as in the original
- Copied the tests from the `OwnableValidator.t.sol` files, and all tests are passing.

(also, I think this implementation has much better structure/readability than the original one)